### PR TITLE
Add basic Express/MongoDB API for magical creatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# backend-api-criaturas
+# API de Criaturas Mágicas
+
+Esta API permite gestionar criaturas mágicas con diferentes rarezas. Está desarrollada con **Node.js**, **Express** y **MongoDB** usando Mongoose.
+
+## Endpoints principales
+
+- `GET /criaturas` – Lista todas las criaturas.
+- `POST /criaturas` – Crea una nueva criatura.
+- `GET /criaturas/:id` – Obtiene una criatura por su id.
+- `PUT /criaturas/:id` – Actualiza una criatura existente.
+- `DELETE /criaturas/:id` – Elimina una criatura.
+
+Cada criatura posee los siguientes atributos:
+
+- `nombre`: nombre de la criatura
+- `rareza`: una de `comun`, `poco comun`, `raro`, `epico`, `legendario`
+- `ataques`: arreglo de tres ataques
+
+## Puesta en marcha
+
+1. Asegúrate de tener MongoDB corriendo y define la variable `MONGODB_URI` si deseas usar otra conexión.
+2. Instala las dependencias con `npm install` (requiere acceso a internet).
+3. Ejecuta `npm run dev` para iniciar el servidor en modo de desarrollo.
+
+La API quedará disponible en `http://localhost:3000`.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,73 @@
+const express = require('express');
+const mongoose = require('mongoose');
+
+const app = express();
+app.use(express.json());
+
+// MongoDB connection
+mongoose.connect(process.env.MONGODB_URI || 'mongodb://localhost:27017/criaturas', {
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
+});
+
+const rarities = ['comun', 'poco comun', 'raro', 'epico', 'legendario'];
+
+// Schema and model
+const criaturaSchema = new mongoose.Schema({
+  nombre: { type: String, required: true },
+  rareza: { type: String, enum: rarities, required: true },
+  ataques: { type: [String], validate: [arr => arr.length === 3, 'Deben ser tres ataques'] }
+});
+
+const Criatura = mongoose.model('Criatura', criaturaSchema);
+
+// CRUD routes
+app.get('/criaturas', async (req, res) => {
+  const criaturas = await Criatura.find();
+  res.json(criaturas);
+});
+
+app.post('/criaturas', async (req, res) => {
+  try {
+    const criatura = new Criatura(req.body);
+    await criatura.save();
+    res.status(201).json(criatura);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+app.get('/criaturas/:id', async (req, res) => {
+  try {
+    const criatura = await Criatura.findById(req.params.id);
+    if (!criatura) return res.status(404).json({ error: 'No encontrada' });
+    res.json(criatura);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+app.put('/criaturas/:id', async (req, res) => {
+  try {
+    const criatura = await Criatura.findByIdAndUpdate(req.params.id, req.body, { new: true, runValidators: true });
+    if (!criatura) return res.status(404).json({ error: 'No encontrada' });
+    res.json(criatura);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+app.delete('/criaturas/:id', async (req, res) => {
+  try {
+    const criatura = await Criatura.findByIdAndDelete(req.params.id);
+    if (!criatura) return res.status(404).json({ error: 'No encontrada' });
+    res.json({ mensaje: 'Eliminada' });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Servidor iniciado en puerto ${PORT}`);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "backend-api-criaturas",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js",
+    "dev": "nodemon index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2",
+    "mongoose": "^7.0.0"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.22"
+  }
+}


### PR DESCRIPTION
## Summary
- initialize Node project with express and mongoose dependencies
- add CRUD API for magical creatures
- document endpoints and usage in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68713cb387fc8325b948114de6f48269